### PR TITLE
Marker size and rotation fixes [#0]

### DIFF
--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -33,21 +33,21 @@ import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 
 public class PluginMarker extends MyPlugin {
-  
+
   private enum Animation {
     DROP,
     BOUNCE
   }
-  
+
   /**
    * Create a marker
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void createMarker(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
-    
+
     // Create an instance of Marker class
     final MarkerOptions markerOptions = new MarkerOptions();
     final JSONObject opts = args.getJSONObject(1);
@@ -85,7 +85,7 @@ public class PluginMarker extends MyPlugin {
     }
     Marker marker = map.addMarker(markerOptions);
 
-    
+
     // Store the marker
     String id = "marker_" + marker.getId();
     this.objects.put(id, marker);
@@ -106,7 +106,7 @@ public class PluginMarker extends MyPlugin {
     result.put("hashCode", marker.hashCode());
     result.put("id", id);
 
-    
+
     // Load icon
     if (opts.has("icon")) {
       Bundle bundle = null;
@@ -114,7 +114,7 @@ public class PluginMarker extends MyPlugin {
       if (JSONObject.class.isInstance(value)) {
         JSONObject iconProperty = (JSONObject)value;
         bundle = PluginUtil.Json2Bundle(iconProperty);
-        
+
         // The `anchor` of the `icon` property
         if (iconProperty.has("anchor")) {
           value = iconProperty.get("anchor");
@@ -154,6 +154,15 @@ public class PluginMarker extends MyPlugin {
       if (opts.has("animation")) {
         bundle.putString("animation", opts.getString("animation"));
       }
+
+      if (opts.has("size")) {
+        JSONObject size = opts.getJSONObject("size");
+        Bundle sizeBundle = new Bundle();
+        sizeBundle.putInt("width", size.getInt("width"));
+        sizeBundle.putInt("height", size.getInt("height"));
+        bundle.putBundle("size", sizeBundle);
+      }
+
       this.setIcon_(marker, bundle, new PluginAsyncInterface() {
 
         @Override
@@ -168,7 +177,7 @@ public class PluginMarker extends MyPlugin {
           } else {
             marker.setVisible(true);
           }
-          
+
 
           // Animation
           String markerAnimation = null;
@@ -202,7 +211,7 @@ public class PluginMarker extends MyPlugin {
         public void onError(String errorMsg) {
           callbackContext.error(errorMsg);
         }
-        
+
       });
     } else {
       String markerAnimation = null;
@@ -217,31 +226,31 @@ public class PluginMarker extends MyPlugin {
           public void onPostExecute(Object object) {
             callbackContext.success(result);
           }
-          
+
           @Override
           public void onError(String errorMsg) {
             callbackContext.error(errorMsg);
           }
-          
+
         });
       } else {
         // Return the result if does not specify the icon property.
         callbackContext.success(result);
       }
     }
-    
+
   }
-  
+
   private void setDropAnimation_(final Marker marker, final PluginAsyncInterface callback) {
     final Handler handler = new Handler();
     final long startTime = SystemClock.uptimeMillis();
     final long duration = 100;
-    
+
     final Projection proj = this.map.getProjection();
     final LatLng markerLatLng = marker.getPosition();
     final Point markerPoint = proj.toScreenLocation(markerLatLng);
     final Point startPoint = new Point(markerPoint.x, 0);
-    
+
     final Interpolator interpolator = new LinearInterpolator();
 
     handler.post(new Runnable() {
@@ -263,7 +272,7 @@ public class PluginMarker extends MyPlugin {
       }
     });
   }
-  
+
   /**
    * Bounce animation
    * http://android-er.blogspot.com/2013/01/implement-bouncing-marker-for-google.html
@@ -272,12 +281,12 @@ public class PluginMarker extends MyPlugin {
     final Handler handler = new Handler();
     final long startTime = SystemClock.uptimeMillis();
     final long duration = 2000;
-    
+
     final Projection proj = this.map.getProjection();
     final LatLng markerLatLng = marker.getPosition();
     final Point startPoint = proj.toScreenLocation(markerLatLng);
     startPoint.offset(0, -200);
-    
+
     final Interpolator interpolator = new BounceInterpolator();
 
     handler.post(new Runnable() {
@@ -300,7 +309,7 @@ public class PluginMarker extends MyPlugin {
       }
     });
   }
-  
+
   private void setMarkerAnimation_(Marker marker, String animationType, PluginAsyncInterface callback) {
     Animation animation = null;
     try {
@@ -320,14 +329,14 @@ public class PluginMarker extends MyPlugin {
     case BOUNCE:
       this.setBounceAnimation_(marker, callback);
       break;
-    
+
     default:
       break;
     }
   }
-  
+
   /**
-   * 
+   *
    * http://android-er.blogspot.com/2013/01/implement-bouncing-marker-for-google.html
    * @param args
    * @param callbackContext
@@ -338,7 +347,7 @@ public class PluginMarker extends MyPlugin {
     String id = args.getString(1);
     String animation = args.getString(2);
     final Marker marker = this.getMarker(id);
-    
+
     this.setMarkerAnimation_(marker, animation, new PluginAsyncInterface() {
 
       @Override
@@ -349,7 +358,7 @@ public class PluginMarker extends MyPlugin {
       public void onError(String errorMsg) {
         callbackContext.error(errorMsg);
       }
-      
+
     });
   }
 
@@ -357,7 +366,7 @@ public class PluginMarker extends MyPlugin {
    * Show the InfoWindow binded with the marker
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void showInfoWindow(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -371,7 +380,7 @@ public class PluginMarker extends MyPlugin {
    * Set rotation for the marker
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setRotation(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -379,12 +388,12 @@ public class PluginMarker extends MyPlugin {
     String id = args.getString(1);
     this.setFloat("setRotation", id, rotation, callbackContext);
   }
-  
+
   /**
    * Set opacity for the marker
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setOpacity(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -392,7 +401,7 @@ public class PluginMarker extends MyPlugin {
     String id = args.getString(1);
     this.setFloat("setAlpha", id, alpha, callbackContext);
   }
-    
+
     /**
      * Set zIndex for the marker (dummy code, not available on Android V2)
      * @param args
@@ -404,7 +413,7 @@ public class PluginMarker extends MyPlugin {
         // nothing to do :(
         // it's a shame google...
     }
-  
+
   /**
    * set position
    * @param args
@@ -419,12 +428,12 @@ public class PluginMarker extends MyPlugin {
     marker.setPosition(position);
     this.sendNoResult(callbackContext);
   }
-  
+
   /**
    * Set flat for the marker
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setFlat(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -437,7 +446,7 @@ public class PluginMarker extends MyPlugin {
    * Set visibility for the object
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   protected void setVisible(JSONArray args, CallbackContext callbackContext) throws JSONException {
     boolean visible = args.getBoolean(2);
@@ -447,7 +456,7 @@ public class PluginMarker extends MyPlugin {
   /**
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   protected void setDisableAutoPan(JSONArray args, CallbackContext callbackContext) throws JSONException {
     boolean disableAutoPan = args.getBoolean(2);
@@ -468,7 +477,7 @@ public class PluginMarker extends MyPlugin {
    * Set title for the marker
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setTitle(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -476,12 +485,12 @@ public class PluginMarker extends MyPlugin {
     String id = args.getString(1);
     this.setString("setTitle", id, title, callbackContext);
   }
-  
+
   /**
    * Set the snippet for the marker
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setSnippet(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -489,12 +498,12 @@ public class PluginMarker extends MyPlugin {
     String id = args.getString(1);
     this.setString("setSnippet", id, snippet, callbackContext);
   }
-  
+
   /**
    * Hide the InfoWindow binded with the marker
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void hideInfoWindow(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -508,25 +517,25 @@ public class PluginMarker extends MyPlugin {
    * Return the position of the marker
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void getPosition(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
     String id = args.getString(1);
     Marker marker = this.getMarker(id);
     LatLng position = marker.getPosition();
-    
+
     JSONObject result = new JSONObject();
     result.put("lat", position.latitude);
     result.put("lng", position.longitude);
     callbackContext.success(result);
   }
-  
+
   /**
    * Return 1 if the InfoWindow of the marker is shown
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void isInfoWindowShown(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -535,12 +544,12 @@ public class PluginMarker extends MyPlugin {
     Boolean isInfoWndShown = marker.isInfoWindowShown();
     callbackContext.success(isInfoWndShown ? 1 : 0);
   }
-  
+
   /**
    * Remove the marker
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void remove(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -552,17 +561,17 @@ public class PluginMarker extends MyPlugin {
     }
     marker.remove();
     this.objects.remove(id);
-    
+
     String propertyId = "marker_property_" + id;
     this.objects.remove(propertyId);
     this.sendNoResult(callbackContext);
   }
-  
+
   /**
    * Set anchor for the icon of the marker
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setIconAnchor(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -570,20 +579,20 @@ public class PluginMarker extends MyPlugin {
     float anchorY = (float)args.getDouble(3);
     String id = args.getString(1);
     Marker marker = this.getMarker(id);
-    
+
     Bundle imageSize = (Bundle) this.objects.get("imageSize");
     if (imageSize != null) {
       this._setIconAnchor(marker, anchorX, anchorY, imageSize.getInt("width"), imageSize.getInt("height"));
     }
     this.sendNoResult(callbackContext);
   }
-  
+
 
   /**
    * Set anchor for the InfoWindow of the marker
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setInfoWindowAnchor(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -591,19 +600,19 @@ public class PluginMarker extends MyPlugin {
     float anchorY = (float)args.getDouble(3);
     String id = args.getString(1);
     Marker marker = this.getMarker(id);
-    
+
     Bundle imageSize = (Bundle) this.objects.get("imageSize");
     if (imageSize != null) {
       this._setInfoWindowAnchor(marker, anchorX, anchorY, imageSize.getInt("width"), imageSize.getInt("height"));
     }
     this.sendNoResult(callbackContext);
   }
-  
+
   /**
    * Set draggable for the marker
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setDraggable(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -611,12 +620,12 @@ public class PluginMarker extends MyPlugin {
     String id = args.getString(1);
     this.setBoolean("setDraggable", id, draggable, callbackContext);
   }
-  
+
   /**
    * Set icon of the marker
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setIcon(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -627,7 +636,7 @@ public class PluginMarker extends MyPlugin {
     if (JSONObject.class.isInstance(value)) {
       JSONObject iconProperty = (JSONObject)value;
       bundle = PluginUtil.Json2Bundle(iconProperty);
-          
+
       // The `anchor` for icon
       if (iconProperty.has("anchor")) {
         value = iconProperty.get("anchor");

--- a/src/ios/GoogleMaps/Marker.m
+++ b/src/ios/GoogleMaps/Marker.m
@@ -91,6 +91,7 @@
     } else {
         iconProperty[@"visible"] = @NO;
     }
+
     // Animation
     NSString *animation = nil;
     if ([json valueForKey:@"animation"]) {
@@ -98,6 +99,12 @@
         if (iconProperty) {
             [iconProperty setObject:animation forKey:@"animation"];
         }
+    }
+
+    // Size
+    NSDictionary *size = [json valueForKey:@"size"];
+    if (iconProperty && size) {
+        [iconProperty setObject:size forKey:@"size"];
     }
 
     NSMutableDictionary *result = [[NSMutableDictionary alloc] init];
@@ -699,7 +706,7 @@
                     #else
                         iconPath = [iconPath stringByReplacingOccurrencesOfString:@"file://" withString:@""];
                     #endif
-                    
+
                     NSFileManager *fileManager = [NSFileManager defaultManager];
                     if (![fileManager fileExistsAtPath:iconPath]) {
                         if (self.mapCtrl.debuggable) {
@@ -838,12 +845,12 @@
     } else if ([iconProperty valueForKey:@"iconColor"]) {
         UIColor *iconColor = [iconProperty valueForKey:@"iconColor"];
         marker.icon = [GMSMarker markerImageWithColor:iconColor];
-        
+
         // The `visible` property
         if ([[iconProperty valueForKey:@"visible"] boolValue]) {
             marker.map = self.mapCtrl.map;
         }
-        
+
         if (animation) {
             // Do animation, then send the result
             [self setMarkerAnimation_:animation marker:marker pluginResult:pluginResult callbackId:callbackId];

--- a/www/googlemaps-cdv-plugin.js
+++ b/www/googlemaps-cdv-plugin.js
@@ -291,7 +291,7 @@ App.prototype._onCameraEvent = function(eventName, params) {
 App.prototype.getMap = function(div, params) {
      // Redraw the browser mandatory (especially for iOS)
     document.body.style.backgroundColor="rgba(0,0,0,0.1)";
-    
+
     var self = this,
         args = [];
 
@@ -1501,8 +1501,8 @@ Marker.prototype.getSnippet = function() {
     return this.get('snippet');
 };
 Marker.prototype.setRotation = function(rotation) {
-    if (!rotation) {
-        console.log('missing value for rotation');
+    if (typeof rotation !== 'number') {
+        console.log('missing or invalid value for rotation');
         return false;
     }
     this.set('rotation', rotation);


### PR DESCRIPTION
Previously, setting the size of a marker was only possible *after* the marker had been created. Now, the addMarker accepts a size parameter to adjust the size of the icon during construction. This is most useful when setting marker images with high-resolution images.

Secondly, this PR fixes a bug in the setRotation marker method that rejects values of 0 due to simply checking if the input rotation value was falsy. Now, only throws this error if the input value is not a number.