### PR TITLE
Adds support for configuring icon anchor from addMarker

### DIFF
--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -155,12 +155,29 @@ public class PluginMarker extends MyPlugin {
         bundle.putString("animation", opts.getString("animation"));
       }
 
-      if (opts.has("size")) {
-        JSONObject size = opts.getJSONObject("size");
+      JSONObject size = opts.optJSONObject("size");
+      if (size != null) {
         Bundle sizeBundle = new Bundle();
         sizeBundle.putInt("width", size.getInt("width"));
         sizeBundle.putInt("height", size.getInt("height"));
         bundle.putBundle("size", sizeBundle);
+      }
+
+      JSONArray iconAnchor = opts.optJSONArray("iconAnchor");
+      if (iconAnchor != null && size != null) {
+        double anchorX = null;
+        double anchorY = null;
+        try {
+          anchorX = iconAnchor.getDouble(0);
+          anchorY = iconAnchor.getDouble(1);
+        }
+        catch (JSONException e) {
+          e.printStackTrace();
+        }
+
+        if (anchorX != null && anchorY != null) {
+          this._setIconAnchor(marker, anchorX, anchorY, size.getInt("width"), size.getInt("height"));
+        }
       }
 
       this.setIcon_(marker, bundle, new PluginAsyncInterface() {

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -165,8 +165,8 @@ public class PluginMarker extends MyPlugin {
 
       JSONArray iconAnchor = opts.optJSONArray("iconAnchor");
       if (iconAnchor != null && size != null) {
-        double anchorX = null;
-        double anchorY = null;
+        double anchorX = -1;
+        double anchorY = -1;
         try {
           anchorX = iconAnchor.getDouble(0);
           anchorY = iconAnchor.getDouble(1);
@@ -175,7 +175,7 @@ public class PluginMarker extends MyPlugin {
           e.printStackTrace();
         }
 
-        if (anchorX != null && anchorY != null) {
+        if (anchorX >= 0 && anchorY >= 0) {
           this._setIconAnchor(marker, anchorX, anchorY, size.getInt("width"), size.getInt("height"));
         }
       }

--- a/src/ios/GoogleMaps/Marker.m
+++ b/src/ios/GoogleMaps/Marker.m
@@ -107,6 +107,18 @@
         [iconProperty setObject:size forKey:@"size"];
     }
 
+    // Icon anchor
+    NSArray *iconAnchor = [json valueForKey:@"iconAnchor"];
+    if ([iconAnchor isKindOfClass:[NSArray class]]) {
+        CGFloat anchorX = [[iconAnchor objectAtIndex:0] floatValue];
+        CGFloat anchorY = [[iconAnchor objectAtIndex:1] floatValue];
+        if (size) {
+            anchorX = anchorX / [size[@"width"] floatValue];
+            anchorY = anchorY / [size[@"height"] floatValue];
+            [marker setGroundAnchor:CGPointMake(anchorX, anchorY)];
+        }
+    }
+
     NSMutableDictionary *result = [[NSMutableDictionary alloc] init];
     [result setObject:id forKey:@"id"];
     [result setObject:[NSString stringWithFormat:@"%lu", (unsigned long)marker.hash] forKey:@"hashCode"];
@@ -127,7 +139,6 @@
         // Load icon in asynchronise
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
         [self setIcon_:marker iconProperty:iconProperty pluginResult:pluginResult callbackId:command.callbackId];
-
     } else {
         if ([[json valueForKey:@"visible"] boolValue] == true) {
             marker.map = self.mapCtrl.map;

--- a/www/googlemaps-cdv-plugin.js
+++ b/www/googlemaps-cdv-plugin.js
@@ -1043,6 +1043,8 @@ App.prototype.addMarker = function(markerOptions, callback) {
     markerOptions.anchor = markerOptions.anchor || [0.5, 0.5];
     markerOptions.draggable = markerOptions.draggable === true;
     markerOptions.icon = markerOptions.icon || undefined;
+    markerOptions.iconAnchor = markerOptions.iconAnchor || undefined;
+    markerOptions.size = markerOptions.size || undefined;
     markerOptions.snippet = markerOptions.snippet || undefined;
     markerOptions.title = markerOptions.title !== undefined ? String(markerOptions.title) : undefined;
     markerOptions.visible = markerOptions.visible === undefined ? true : markerOptions.visible;


### PR DESCRIPTION
addMarker does not support setting the icon anchor and defaults it it to the bottom middle (to accommodate the default upside-down rain drop pin). All our icons are anchored in the horizontal and vertical center. This requires a second call to gmaps with the correct icon anchor potentially causing the icons to jump from their default position to the new anchor. Additionally, rotation is done around the anchor point, which with the default offset produces the wrong effect.

This PR adds support to specify the iconAnchor as part of the addMarker method to address the above concerns.