### PR TITLE
reference 'anchor' property instead of 'iconAnchor'

### DIFF
--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -163,21 +163,12 @@ public class PluginMarker extends MyPlugin {
         bundle.putBundle("size", sizeBundle);
       }
 
-      JSONArray iconAnchor = opts.optJSONArray("iconAnchor");
-      if (iconAnchor != null && size != null) {
-        double anchorX = -1;
-        double anchorY = -1;
-        try {
-          anchorX = iconAnchor.getDouble(0);
-          anchorY = iconAnchor.getDouble(1);
-        }
-        catch (JSONException e) {
-          e.printStackTrace();
-        }
-
-        if (anchorX >= 0 && anchorY >= 0) {
-          this._setIconAnchor(marker, anchorX, anchorY, size.getInt("width"), size.getInt("height"));
-        }
+      JSONArray anchor = opts.optJSONArray("anchor");
+      if (anchor != null && anchor.length() == 2) {
+        double[] anchorPoints = new double[2];
+        anchorPoints[0] = anchor.getDouble(0);
+        anchorPoints[1] = anchor.getDouble(1);
+        bundle.putDoubleArray("anchor", anchorPoints);
       }
 
       this.setIcon_(marker, bundle, new PluginAsyncInterface() {

--- a/src/ios/GoogleMaps/Marker.m
+++ b/src/ios/GoogleMaps/Marker.m
@@ -108,15 +108,9 @@
     }
 
     // Icon anchor
-    NSArray *iconAnchor = [json valueForKey:@"iconAnchor"];
-    if ([iconAnchor isKindOfClass:[NSArray class]]) {
-        CGFloat anchorX = [[iconAnchor objectAtIndex:0] floatValue];
-        CGFloat anchorY = [[iconAnchor objectAtIndex:1] floatValue];
-        if (size) {
-            anchorX = anchorX / [size[@"width"] floatValue];
-            anchorY = anchorY / [size[@"height"] floatValue];
-            [marker setGroundAnchor:CGPointMake(anchorX, anchorY)];
-        }
+    NSArray *anchor = [json valueForKey:@"anchor"];
+    if (iconProperty && anchor) {
+        [iconProperty setObject:anchor forKey:@"anchor"];
     }
 
     NSMutableDictionary *result = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
Turns out that the native plugin uses the 'anchor' property instead of 'iconAnchor' when setting the icon anchor point. Even so, it was not setting the anchor property during addMarker. This PR refactors to accommodate these changes.